### PR TITLE
add exit codes 0 for continuous integration

### DIFF
--- a/lib/trail_marker/api_testrail.rb
+++ b/lib/trail_marker/api_testrail.rb
@@ -328,37 +328,4 @@ class ApiTestRail
     end
     return retval
   end
-  
-   
-  # NOTE: MARK_TEST_PLAN
-  # User Input: Project Name, TestRun Name
-  # Project Name > Get project_id
-  # Call API get_plans/project_id to get all test plans for the project
-  # Get testplan_id of testplan with the given name
-  # Call API get_plan/testplan_id to get testruns inside this testplan
-  # 
-  
-  
-  
-  
-  
-  ############### DELETE THESE NOT USED
-  
-  # TODO: Parse XML for failed reason and add to comment(?)
-  #
-  # def markoff_test(case_id, run_id, pass_status)
-    # status_id = search_array_kv(@statuses, 'name', 'failed', 'id')
-    # defect_txt = ""
-    # if pass_status
-      # status_id = search_array_kv(@statuses, 'name', 'passed', 'id')
-      # defect_txt = ""
-    # end
-    # equiv_json = {:status_id => status_id, :comment => 'Auto marker.', :defects => defect_txt}
-    # add_result_req = "add_result_for_case/" + run_id.to_s + "/" + case_id.to_s
-    # request_post(add_result_req, equiv_json)
-  # end
-#   
-  
- 
-  
 end

--- a/lib/trail_marker/mark_tests.rb
+++ b/lib/trail_marker/mark_tests.rb
@@ -163,6 +163,7 @@ class MarkTests
 
   def show_exit_msg
     puts "\n#{EXIT_MSG}\n"
+    exit 0
   end
 
 

--- a/lib/trail_marker/request.rb
+++ b/lib/trail_marker/request.rb
@@ -80,7 +80,7 @@ class Request
 
   def exit_script()
     msg("Exiting script.")
-    exit(1)
+    exit(0)
   end
 
   def msg(msg_txt)

--- a/lib/trail_marker/version.rb
+++ b/lib/trail_marker/version.rb
@@ -1,3 +1,3 @@
 module TrailMarker
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end


### PR DESCRIPTION
**Before**
- Exit codes are not specified resulting in random integer
- Continuous integration systems will interpret exit code as fail

**After**
- all exit codes set to 0 to make sure CI systems does not register a fail with this command.
- removed junk code
- update version to 0.1.2